### PR TITLE
Issue-3: [feat][entrypoint, Dockerfile] Update to clang-format-10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
-RUN sudo apt install clang-format-10
+RUN apt-get install clang-format-10
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
 RUN apt-get update
-RUN apt-get install clang-format-10
+RUN apt-get install -y clang-format-10
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
+RUN apt-get update
 RUN apt-get install clang-format-10
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM ubuntu:latest
 
 LABEL "com.github.actions.name"="clang-format C Check"
 LABEL "com.github.actions.description"="Run clang-format style check for C programs."
@@ -9,8 +9,7 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
-RUN pip install --upgrade pip
-RUN pip install clang-format
+RUN sudo apt install clang-format-10
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,5 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
-RUN apt-get update
-RUN apt-get install -y clang-format-10
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,12 +21,12 @@ apt-get install -y clang-format-10 || exit 3
 # compared to the original file.
 format_diff(){
     local filepath="$1"
-    local_format="$(clang-format -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
-    format-status="$?"
-    if [[ "${format-status}" -ne 0 ]]; then
+    local_format="$(/usr/bin/clang-format-10 -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
+    local format_status="$?"
+    if [[ "${format_status}" -ne 0 ]]; then
 	echo "$local_format" >&2
 	exit_code=1
-	return "${format-status}"
+	return "${format_status}"
     fi
     return 0
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,13 +18,12 @@
 # compared to the original file.
 format_diff(){
     local filepath="$1"
-    local_format="$(clang-format --style=file --fallback-style=LLVM "${filepath}")"
-    diff -q <(cat "${filepath}") <(echo "${local_format}") > /dev/null
-    diff_result="$?"
-    if [[ "${diff_result}" -ne 0 ]]; then
-	echo "${filepath} is not formatted correctly." >&2
+    local_format="$(clang-format -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
+    format-status="$?"
+    if [[ "${format-status}" -ne 0 ]]; then
+	echo "$local_format" >&2
 	exit_code=1
-	return "${diff_result}"
+	return "${format-status}"
     fi
     return 0
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,9 @@
 # Define your own formatting rules in a .clang-format file at your repository
 # root. Otherwise, the LLVM style guide is used as a default.
 
+# Install clang-format 10.0.0
+sudo apt-get update
+sudo apt-get install -y clang-format-10
 
 ###############################################################################
 #                             format_diff function                            #
@@ -28,7 +31,7 @@ format_diff(){
     return 0
 }
 
-cd "$GITHUB_WORKSPACE" || exit 1
+cd "$GITHUB_WORKSPACE" || exit 2
 
 # initialize exit code
 exit_code=0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@
 # root. Otherwise, the LLVM style guide is used as a default.
 
 # Install clang-format 10.0.0
-sudo apt-get update
-sudo apt-get install -y clang-format-10
+apt-get update || exit 3
+apt-get install -y clang-format-10 || exit 3
 
 ###############################################################################
 #                             format_diff function                            #


### PR DESCRIPTION
**Why this change was necessary**
clang-format 10.0.0 has some new rules for handling line endings more
robustly. For other new rules, see the release notes linked below.

For this implementation, clang-format 10.0.0 has a new `--dry-run` or
`-n` option to emit a warning when formatting rules are not
respected. These warnings can be escalated to errors with the
`--Werror` option which additionally returns a non-zero exit code on
formatting violations.

**What this change does**
The Dockerfile now uses the lates Ubuntu LTS version and installs
`clang-format-10` via `apt`.

**Any side-effects?**
Diffs between the original and formatted source file no longer need to
be stored in memory.

The output messages emitted are no longer string literals defined in
`entrypoint.sh` and are instead the direct stderr output of
`clang-format`.

**Additional context/notes/links**

Resolves: #3
Related to: [clang-format 10.0.0 release notes](
https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html#clang-format)