### PR TITLE
Issue 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
+# Install clang-format
+RUN apt-get update && apt-get install -y --no-install-recommends clang-format-10
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clang-format-action
 GitHub Action for clang-format
 
-This action checks all C files (.c and .h) in the GitHub workspace are formatted correctly using the [precompiled Python wheel](https://pypi.org/project/clang-format/) for `clang-format`.
+This action checks all C files (.c and .h) in the GitHub workspace are formatted correctly using `clang-format`.
 
 The action returns:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,6 @@
 # Define your own formatting rules in a .clang-format file at your repository
 # root. Otherwise, the LLVM style guide is used as a default.
 
-# Install clang-format 10.0.0
-apt-get update || exit 3
-apt-get install -y clang-format-10 || exit 3
-
 ###############################################################################
 #                             format_diff function                            #
 ###############################################################################


### PR DESCRIPTION
**Why this change was necessary**
Installing within the docker image cleans up the logs when using the action.

**What this change does**
Moves `apt-get` commands from `entrypoint.sh` to `Dockerfile`.

**Additional context/notes/links**

Resolves: #6