### PR TITLE
[docs][README] Change branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C programs.
-      uses: jidicula/clang-format-action@master
+      uses: jidicula/clang-format-action@main
 ```


### PR DESCRIPTION
Resolves #10

**Why this change was necessary**
It's 2020 and we call the trunk branch `main`.

**What this change does**
See title.

**Any side-effects?**
Probably lots, but not in this repo.