### PR TITLE
update clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM archlinux:latest
 
 LABEL "com.github.actions.name"="clang-format C Check"
 LABEL "com.github.actions.description"="Run clang-format style check for C programs."
@@ -9,8 +9,12 @@ LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan.idicula@mail.mcgill.ca>"
 
-# Install clang-format
-RUN apt-get update && apt-get install -y --no-install-recommends clang-format-10
+# Perform system update
+RUN pacman -Syyu --noconfirm
+
+# Install clang, which contains clang-format
+RUN pacman -S --noconfirm clang
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@
 # compared to the original file.
 format_diff(){
     local filepath="$1"
-    local_format="$(/usr/bin/clang-format-10 -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
+    local_format="$(/usr/bin/clang-format -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
     local format_status="$?"
     if [[ "${format_status}" -ne 0 ]]; then
 	echo "$local_format" >&2


### PR DESCRIPTION
* use archlinux:latest instead of ubuntu:latest (it's more lightweight)

* always use the newest clang

* add newlines at the end of files

I also think this Action should support C++ files (`.cpp`, `.cxx` and `.hpp`), but I'm not sure whether you want that. In the end I can fork and create my own variation, but given that there's no _good_ clang-format GitHub Action, I'd like to at least help create one :)