### PR TITLE
[feat][entrypoint] Support all C/C++ files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,28 @@
 # clang-format-action
 GitHub Action for clang-format
 
-This action checks all C files (`.c` and `.h`) in the GitHub workspace are formatted correctly using `clang-format`.
+This action checks all C/C++ files in the GitHub workspace are formatted correctly using `clang-format`.
+
+The following file extensions are checked:
+* Header files:
+  * `.h`
+  * `.H`
+  * `.hpp`
+  * `.hh`
+  * `.h++`
+  * `.hxx `
+* Source files:
+  * `.c`
+  * `.C`
+  * `.cpp`
+  * `.cc`
+  * `.c++`
+  * `.cxx`
 
 The action returns:
 
-* SUCCESS: zero exit-code if project C files are formatted correctly
-* FAILURE: nonzero exit-code if project C files are not formatted correctly
+* SUCCESS: zero exit-code if project C/C++ files are formatted correctly
+* FAILURE: nonzero exit-code if project C/C++ files are not formatted correctly
 
 Define your own formatting rules in a `.clang-format` file at your repository root. Otherwise, the LLVM style guide is used as a default. My preference is the [Linux Project format](https://github.com/torvalds/linux/blob/master/.clang-format).
 
@@ -24,6 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run clang-format style check for C programs.
+    - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v1.1.2
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "clang-format Check"
-description: "Use clang-format to see if your C code is formatted according to project guidelines."
+description: "Use clang-format to see if your C/C++ code is formatted according to project guidelines."
 
 branding:
   icon: "check-circle"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,17 +3,16 @@
 ###############################################################################
 #                                entrypoint.sh                                #
 ###############################################################################
-# Checks all C files (.c and .h) in the GitHub workspace for conforming to
-# clang-format. If any C files are incorrectly formatted, the script lists them
-# and exits with 1.
+# Checks all C/C++ files (.h, .H, .hpp, .hh, .h++, .hxx and .c, .C, .cpp, .cc,
+# .c++, .cxx) in the GitHub workspace for conforming to clang-format. If any C
+# files are incorrectly formatted, the script lists them and exits with 1.
+#
 # Define your own formatting rules in a .clang-format file at your repository
 # root. Otherwise, the LLVM style guide is used as a default.
 
-###############################################################################
-#                             format_diff function                            #
-###############################################################################
+# format_diff function
 # Accepts a filepath argument. The filepath passed to this function must point
-# to a .c or .h file. The file is formatted with clang-format and that output is
+# to a C/C++ file. The file is formatted with clang-format and that output is
 # compared to the original file.
 format_diff() {
 	local filepath="$1"
@@ -33,8 +32,10 @@ cd "$GITHUB_WORKSPACE" || exit 2
 exit_code=0
 
 # All files improperly formatted will be printed to the output.
-# find all C .c and .h files'
-c_files=$(find . -name "*.[hc]")
+# find all C/C++ files:
+#   h, H, hpp, hh, h++, hxx
+#   c, C, cpp, cc, c++, cxx
+c_files=$(find . | grep -E '\.((c|C)c?(pp|xx|\+\+)*$|(h|H)h?(pp|xx|\+\+)*$)')
 
 # check formatting in each C file
 for file in $c_files; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,16 +15,16 @@
 # Accepts a filepath argument. The filepath passed to this function must point
 # to a .c or .h file. The file is formatted with clang-format and that output is
 # compared to the original file.
-format_diff(){
-    local filepath="$1"
-    local_format="$(/usr/bin/clang-format-10 -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
-    local format_status="$?"
-    if [[ "${format_status}" -ne 0 ]]; then
-	echo "$local_format" >&2
-	exit_code=1
-	return "${format_status}"
-    fi
-    return 0
+format_diff() {
+	local filepath="$1"
+	local_format="$(/usr/bin/clang-format-10 -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
+	local format_status="$?"
+	if [[ "${format_status}" -ne 0 ]]; then
+		echo "$local_format" >&2
+		exit_code=1
+		return "${format_status}"
+	fi
+	return 0
 }
 
 cd "$GITHUB_WORKSPACE" || exit 2
@@ -33,12 +33,12 @@ cd "$GITHUB_WORKSPACE" || exit 2
 exit_code=0
 
 # All files improperly formatted will be printed to the output.
-# find all C .c and .h files
+# find all C .c and .h files'
 c_files=$(find . -name "*.[hc]")
 
 # check formatting in each C file
 for file in $c_files; do
-    format_diff "${file}"
+	format_diff "${file}"
 done
 
 exit "$exit_code"


### PR DESCRIPTION
Resolves #18

**Why this change was necessary**
The shellscript previously did not search all possible C files, and
did not support C++ files.

**What this change does**
 - Searches for all possible C files, both source and headers
 - Searches for all possible C++ files, both source and headers

**Any side-effects?**
None