### PR TITLE
[feat] Allow check path selection by user 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v2.0.0
+      uses: jidicula/clang-format-action@v3.0.0
       with:
         check-path: 'src'
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # clang-format-action
 GitHub Action for clang-format
 
-This action checks all C/C++ files in the GitHub workspace are formatted correctly using `clang-format`.
+This action checks all C/C++ files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++ files are checked.
 
 The following file extensions are checked:
 * Header files:
@@ -46,4 +46,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v2.0.0
+      with:
+        check-path: 'src'
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,14 @@ branding:
   icon: "check-circle"
   color: "blue"
 
+inputs:
+  check-path:
+    description: 'The path to the directory you want to check for correct C/C++formatting. Default is the full repository.'
+    required: false
+    default: '.'
+
 runs:
   using: "docker"
   image: "Dockerfile"
+  args:
+    - ${{ inputs.check-path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,10 @@
 #                                entrypoint.sh                                #
 ###############################################################################
 # Checks all C/C++ files (.h, .H, .hpp, .hh, .h++, .hxx and .c, .C, .cpp, .cc,
-# .c++, .cxx) in the GitHub workspace for conforming to clang-format. If any C
-# files are incorrectly formatted, the script lists them and exits with 1.
+# .c++, .cxx) in the provided GitHub repository path for conforming to
+# clang-format. If no path is provided or provided path is not a directory, all
+# C/C++ files are checked. If any C files are incorrectly formatted, the script
+# lists them and exits with 1.
 #
 # Define your own formatting rules in a .clang-format file at your repository
 # root. Otherwise, the LLVM style guide is used as a default.
@@ -26,7 +28,14 @@ format_diff() {
 	return 0
 }
 
+CHECK_PATH="$1"
+
 cd "$GITHUB_WORKSPACE" || exit 2
+
+if [[ ! -d "$CHECK_PATH" ]]; then
+	echo "Not a directory in the workspace, fallback to all files."
+	CHECK_PATH="."
+fi
 
 # initialize exit code
 exit_code=0
@@ -35,7 +44,7 @@ exit_code=0
 # find all C/C++ files:
 #   h, H, hpp, hh, h++, hxx
 #   c, C, cpp, cc, c++, cxx
-c_files=$(find . | grep -E '\.((c|C)c?(pp|xx|\+\+)*$|(h|H)h?(pp|xx|\+\+)*$)')
+c_files=$(find "$CHECK_PATH" | grep -E '\.((c|C)c?(pp|xx|\+\+)*$|(h|H)h?(pp|xx|\+\+)*$)')
 
 # check formatting in each C file
 for file in $c_files; do


### PR DESCRIPTION
Resolves #27

**Why this change was necessary**
Many projects have some directories that are not compliant with the
clang-format config, so the users want to be able to select which
directories get checked.

**What this change does**
Adds an input argument to this action defining which path to check.

**Any side-effects?**
None.