### PR TITLE
feat(input): Allow user to specify clang-format version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:groovy
 
 LABEL "com.github.actions.name"="clang-format C Check"
 LABEL "com.github.actions.description"="Run clang-format style check for C programs."
@@ -8,9 +8,6 @@ LABEL "com.github.actions.color"="blue"
 LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
 LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
 LABEL "maintainer"="jidicula <johanan@forcepush.tech>"
-
-# Install clang-format
-RUN apt-get update && apt-get install -y --no-install-recommends clang-format-10
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
 FROM ubuntu:groovy
 
-LABEL "com.github.actions.name"="clang-format C Check"
-LABEL "com.github.actions.description"="Run clang-format style check for C programs."
-LABEL "com.github.actions.icon"="check-circle"
-LABEL "com.github.actions.color"="blue"
-
-LABEL "repository"="https://github.com/jidicula/github-action-clang-format.git"
-LABEL "homepage"="https://github.com/jidicula/github-action-clang-format"
-LABEL "maintainer"="jidicula <johanan@forcepush.tech>"
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 GitHub Action for clang-format
 
 ## Inputs
+* `clang-format-version` [optional]: The version of `clang-format` that you want to run on your codebase.
+  * Default: `10`
+  * Available versions: every version of `clang-format` available on [Ubuntu Groovy](https://packages.ubuntu.com/search?suite=groovy&searchon=names&keywords=clang-format).
 * `check-path` [optional]: The path to the directory in the repo that should be checked for C/C++ formatting.
   * Default: `.`
   * For cleaner output (i.e. with no double-slashed paths), the final directory in this path should have no trailing slash, e.g. `src` and not `src/`.
@@ -50,8 +53,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.0.0
+      uses: jidicula/clang-format-action@v3.1.0
       with:
+        clang-format-version: '11'
         check-path: 'src'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: "blue"
 
 inputs:
+  clang-format-version:
+    description: 'The version of clang-format that you want to use.'
+    required: false
+    default: '10'
   check-path:
     description: 'The path to the directory you want to check for correct C/C++formatting. Default is the full repository.'
     required: false
@@ -14,5 +18,7 @@ inputs:
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    CLANG_FORMAT_VERSION: ${{ inputs.clang-format-version }}
   args:
     - ${{ inputs.check-path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@
 # compared to the original file.
 format_diff() {
 	local filepath="$1"
-	local_format="$(/usr/bin/clang-format-10 -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
+	local_format="$(/usr/bin/clang-format-"$CLANG_FORMAT_VERSION" -n --Werror --style=file --fallback-style=LLVM "${filepath}")"
 	local format_status="$?"
 	if [[ "${format_status}" -ne 0 ]]; then
 		echo "$local_format" >&2
@@ -29,6 +29,10 @@ format_diff() {
 }
 
 CHECK_PATH="$1"
+
+# Install clang-format
+echo "Installing clang-format-$CLANG_FORMAT_VERSION"
+apt-get update && apt-get install -y --no-install-recommends clang-format-"$CLANG_FORMAT_VERSION"
 
 cd "$GITHUB_WORKSPACE" || exit 2
 


### PR DESCRIPTION
Creates a new input to the action specifying version. That input is
set as an environment variable in the action, which is read in the
Dockerfile when apt-installing `clang-format`.

Resolves: #9