### PR TITLE
Add exclude-regex input

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
 * `fallback-style` [optional]: The fallback style for `clang-format` if no `.clang-format` file exists in your repository.
   * Default: `llvm`
   * Available values: `LLVM`, `Google`, `Chromium`, `Mozilla`, `WebKit` and others listed in the `clang-format` [docs for BasedOnStyle](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options).
+* `exclude-regex` [optional]: A regex to exclude files or directories that should not be checked.
+  * Default: `^$`
+  * Pattern matching is done with a real regex, not a glob expression. You can exclude multiple patterns like this: `(hello|world)`.
 
 This action checks all C/C++ files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++ files are checked.
 
@@ -88,6 +91,34 @@ jobs:
       with:
         clang-format-version: '11'
         check-path: ${{ matrix.path }}
+        fallback-style: 'Mozilla' # optional
+```
+
+## Multiple Paths with Exclusion Regexes
+To use this action on multiple paths in parallel with exclusions, create a `.github/workflows/clang-format-check.yml` in your repository containing:
+
+```yaml
+name: clang-format Check
+on: [push, PR]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - check: 'src'
+            exclude: '(hello|world)' # Exclude file paths containing "hello" or "world"
+          - check: 'examples'
+            exclude: ''              # Nothing to exclude
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.2.0
+      with:
+        clang-format-version: '11'
+        check-path: ${{ matrix.path['check'] }}
+        exclude-regex: ${{ matrix.path['exclude'] }}
         fallback-style: 'Mozilla' # optional
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,13 @@ inputs:
     required: false
     default: '10'
   check-path:
-    description: 'The path to the directory you want to check for correct C/C++formatting. Default is the full repository.'
+    description: 'The path to the directory you want to check for correct C/C++ formatting. Default is the full repository.'
     required: false
     default: '.'
+  exclude-regex:
+    description: 'A regex to exclude files or directories that should not be checked. Default is empty.'
+    required: false
+    default: ''
   fallback-style:
     description: 'The fallback style for clang-format if no .clang-format file exists in your repository.'
     required: false
@@ -27,3 +31,4 @@ runs:
   args:
     - ${{ inputs.check-path }}
     - ${{ inputs.fallback-style }}
+    - ${{ inputs.exclude-regex }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,11 +38,11 @@ if [ -z "$EXCLUDE_REGEX" ]; then
 	EXCLUDE_REGEX="^$"
 fi
 
-# # Install clang-format
-# echo "Installing clang-format-$CLANG_FORMAT_VERSION"
-# apt-get update && apt-get install -y --no-install-recommends clang-format-"$CLANG_FORMAT_VERSION"
+# Install clang-format
+echo "Installing clang-format-$CLANG_FORMAT_VERSION"
+apt-get update && apt-get install -y --no-install-recommends clang-format-"$CLANG_FORMAT_VERSION"
 
-# cd "$GITHUB_WORKSPACE" || exit 2
+cd "$GITHUB_WORKSPACE" || exit 2
 
 if [[ ! -d "$CHECK_PATH" ]]; then
 	echo "Not a directory in the workspace, fallback to all files."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,12 +31,18 @@ format_diff() {
 
 CHECK_PATH="$1"
 FALLBACK_STYLE="$2"
+EXCLUDE_REGEX="$3"
 
-# Install clang-format
-echo "Installing clang-format-$CLANG_FORMAT_VERSION"
-apt-get update && apt-get install -y --no-install-recommends clang-format-"$CLANG_FORMAT_VERSION"
+# Set the regex to an empty string regex if nothing was provided
+if [ -z "$EXCLUDE_REGEX" ]; then
+	EXCLUDE_REGEX="^$"
+fi
 
-cd "$GITHUB_WORKSPACE" || exit 2
+# # Install clang-format
+# echo "Installing clang-format-$CLANG_FORMAT_VERSION"
+# apt-get update && apt-get install -y --no-install-recommends clang-format-"$CLANG_FORMAT_VERSION"
+
+# cd "$GITHUB_WORKSPACE" || exit 2
 
 if [[ ! -d "$CHECK_PATH" ]]; then
 	echo "Not a directory in the workspace, fallback to all files."
@@ -54,7 +60,10 @@ c_files=$(find "$CHECK_PATH" | grep -E '\.((c|C)c?(pp|xx|\+\+)*$|(h|H)h?(pp|xx|\
 
 # check formatting in each C file
 for file in $c_files; do
-	format_diff "${file}"
+	# Only check formatting if the path doesn't match the regex
+	if ! [[ "${file}" =~ $EXCLUDE_REGEX ]]; then
+		format_diff "${file}"
+	fi
 done
 
 exit "$exit_code"


### PR DESCRIPTION
Adds an exclude-regex input so that subdirectories and files may be
omitted from the format check.

I tested this locally by simply running the `entrypoint.sh` script with various arguments.
I'm not 100% certain that this part in the yaml file will work:
```
        check-path: ${{ matrix.path['check'] }}
        exclude-regex: ${{ matrix.path['exclude'] }}
```
