### PR TITLE
Change triggering event from PR to pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use this action, create a `.github/workflows/clang-format-check.yml` in your 
 
 ```yaml
 name: clang-format Check
-on: [push, PR]
+on: [push, pull_request]
 jobs:
   formatting-check:
     name: Formatting Check
@@ -74,7 +74,7 @@ To use this action on multiple paths in parallel, create a `.github/workflows/cl
 
 ```yaml
 name: clang-format Check
-on: [push, PR]
+on: [push, pull_request]
 jobs:
   formatting-check:
     name: Formatting Check
@@ -99,7 +99,7 @@ To use this action on multiple paths in parallel with exclusions, create a `.git
 
 ```yaml
 name: clang-format Check
-on: [push, PR]
+on: [push, pull_request]
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
This action is super useful and very easy to use! I had one small problem setting it up though.

I tried copy/pasting one of the examples from the readme but got an error about `PR` not being a valid event name. 
I checked the [GitHub Action reference][1] and it looks like the event name should be `pull_request`.

Hopefully I am not missing anything. Thanks again for building this great action.

[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows