### PR TITLE
Add support for proto/pb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
 * `clang-format-version` [optional]: The version of `clang-format` that you want to run on your codebase.
   * Default: `13`
   * Available versions: every version of `clang-format` available on [Debian Sid](https://packages.debian.org/search?suite=sid&searchon=names&keywords=clang-format).
-* `check-path` [optional]: The path to the directory in the repo that should be checked for C/C++ formatting.
+* `check-path` [optional]: The path to the directory in the repo that should be checked for C/C++/Protobuf formatting.
   * Default: `.`
   * For cleaner output (i.e. with no double-slashed paths), the final directory in this path should have no trailing slash, e.g. `src` and not `src/`.
 * `fallback-style` [optional]: The fallback style for `clang-format` if no `.clang-format` file exists in your repository.
@@ -31,7 +31,7 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
   * Default: `^$`
   * Pattern matching is done with a real regex, not a glob expression. You can exclude multiple patterns like this: `(hello|world)`.
 
-This action checks all C/C++ (including Arduino `.ino` and `.pde`) files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++ files are checked.
+This action checks all C/C++/Protobuf (including Arduino `.ino` and `.pde`) files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++/Protobuf files are checked.
 
 The following file extensions are checked:
 * Header files:
@@ -50,11 +50,13 @@ The following file extensions are checked:
   * `.cxx`
   * `.ino`
   * `.pde`
+* Protobuf files:
+  * `.proto`
 
 ## Returns:
 
-* SUCCESS: zero exit-code if C/C++ files in `check-path` are formatted correctly
-* FAILURE: nonzero exit-code if C/C++ files in `check-path` are not formatted correctly
+* SUCCESS: zero exit-code if C/C++/Protobuf files in `check-path` are formatted correctly
+* FAILURE: nonzero exit-code if C/C++/Protobuf files in `check-path` are not formatted correctly
 
 # Usage
 
@@ -71,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run clang-format style check for C/C++ programs.
+    - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.3.0
       with:
         clang-format-version: '13'
@@ -96,7 +98,7 @@ jobs:
           - 'examples'
     steps:
     - uses: actions/checkout@v2
-    - name: Run clang-format style check for C/C++ programs.
+    - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.3.0
       with:
         clang-format-version: '13'
@@ -123,7 +125,7 @@ jobs:
             exclude: ''              # Nothing to exclude
     steps:
     - uses: actions/checkout@v2
-    - name: Run clang-format style check for C/C++ programs.
+    - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.3.0
       with:
         clang-format-version: '13'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "clang-format Check"
-description: "Use clang-format to see if your C/C++ code is formatted according to project guidelines."
+description: "Use clang-format to see if your C/C++/Protobuf code is formatted according to project guidelines."
 
 branding:
   icon: "check-circle"
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: '13'
   check-path:
-    description: 'The path to the directory you want to check for correct C/C++ formatting. Default is the full repository.'
+    description: 'The path to the directory you want to check for correct C/C++/Protobuf formatting. Default is the full repository.'
     required: false
     default: '.'
   exclude-regex:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,19 @@
 #                                entrypoint.sh                                #
 ###############################################################################
 # USAGE: ./entrypoint.sh [<path>] [<fallback style>]
-# Checks all C/C++ files (.h, .H, .hpp, .hh, .h++, .hxx and .c, .C, .cpp, .cc,
-# .c++, .cxx) in the provided GitHub repository path (arg1) for conforming to
-# clang-format. If no path is provided or provided path is not a directory, all
-# C/C++ files are checked. If any C files are incorrectly formatted, the script
-# lists them and exits with 1.
+#
+# Checks all C/C++/Protobuf files (.h, .H, .hpp, .hh, .h++, .hxx and .c, .C,
+# .cpp, .cc, .c++, .cxx, .proto) in the provided GitHub repository path
+# (arg1) for conforming to clang-format. If no path is provided or provided path
+# is not a directory, all C/C++/Protobuf files are checked. If any C files are
+# incorrectly formatted, the script lists them and exits with 1.
 #
 # Define your own formatting rules in a .clang-format file at your repository
 # root. Otherwise, the provided style guide (arg2) is used as a fallback.
 
 # format_diff function
 # Accepts a filepath argument. The filepath passed to this function must point
-# to a C/C++ file.
+# to a C/C++/Protobuf file.
 format_diff() {
 	local filepath="$1"
 	# Invoke clang-format with dry run and formatting error output
@@ -55,10 +56,12 @@ fi
 exit_code=0
 
 # All files improperly formatted will be printed to the output.
-# find all C/C++ files:
+# find all C/C++/Protobuf files:
 #   h, H, hpp, hh, h++, hxx
 #   c, C, cpp, cc, c++, cxx
-c_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde))$')
+#   ino, pde
+#   proto
+c_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde)|(proto))$')
 
 # check formatting in each C file
 for file in $c_files; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,10 +61,10 @@ exit_code=0
 #   c, C, cpp, cc, c++, cxx
 #   ino, pde
 #   proto
-c_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde)|(proto))$')
+src_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde)|(proto))$')
 
-# check formatting in each C file
-for file in $c_files; do
+# check formatting in each source file
+for file in $src_files; do
 	# Only check formatting if the path doesn't match the regex
 	if ! [[ "${file}" =~ $EXCLUDE_REGEX ]]; then
 		format_diff "${file}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@
 # Checks all C/C++/Protobuf files (.h, .H, .hpp, .hh, .h++, .hxx and .c, .C,
 # .cpp, .cc, .c++, .cxx, .proto) in the provided GitHub repository path
 # (arg1) for conforming to clang-format. If no path is provided or provided path
-# is not a directory, all C/C++/Protobuf files are checked. If any C files are
+# is not a directory, all C/C++/Protobuf files are checked. If any files are
 # incorrectly formatted, the script lists them and exits with 1.
 #
 # Define your own formatting rules in a .clang-format file at your repository

--- a/test/known_fail/addition.proto
+++ b/test/known_fail/addition.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package addition;
+
+message add_res { uint64 result = 1; }
+message add_req {
+	uint64 a = 1; uint64 b = 2;
+}
+
+service addition {
+	rpc add(add_req) returns (add_res);
+}

--- a/test/known_pass/addition.proto
+++ b/test/known_pass/addition.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package addition;
+
+message add_res
+{
+	uint64 result = 1;
+}
+message add_req
+{
+	uint64 a = 1;
+	uint64 b = 2;
+}
+
+service addition
+{
+	rpc add(add_req) returns (add_res);
+}


### PR DESCRIPTION
This adds support for protobuf files extensions `.proto`.

Used here: https://github.com/helium/proto