### PR TITLE
chore: switch to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:focal
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Ubuntu Groovy is EOL and the package repos don't seem to be available anymore

Fixes #62

---

Ubuntu 20.04 supports clang-format up to version 12 it seems. Not sure if Groovy used to supported more versions.