### PR TITLE
Attempt to fix internal git files being detected by find

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ exit_code=0
 #   c, C, cpp, cc, c++, cxx
 #   ino, pde
 #   proto
-src_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde)|(proto))$')
+src_files=$(find "$CHECK_PATH" -name .git -prune -o -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde)|(proto))$' -print)
 
 # check formatting in each source file
 for file in $src_files; do


### PR DESCRIPTION
This find command seems to work from my bare-bones testing in a personal project. Let's see if it holds up in the context of this action

Closes #66

This PR adds a seperate condition to the find command that, to the best of my understanding, filters out the .git directory and it's contents to the left side of that `-o` (or) and adding the `-print` to the right side (the original query) makes it only print the results of that and not the .git directory matched by the left side.

(Not an expert with find - I just looked stuff up and read a bit in the documentation)