### PR TITLE
fix: Ignore .git files from C/C++ file suffix in branchname

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ exit_code=0
 # find all C/C++ files:
 #   h, H, hpp, hh, h++, hxx
 #   c, C, cpp, cc, c++, cxx
-c_files=$(find "$CHECK_PATH" -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde))$')
+c_files=$(find "$CHECK_PATH" -name .git -prune -o -regextype posix-egrep -regex '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde))$' -print)
 
 # check formatting in each C file
 for file in $c_files; do


### PR DESCRIPTION
Backport of #67