### PR TITLE
feat(clang-format): Add workflow for Docker image build and push

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -2,6 +2,8 @@ name: docker-clang-format
 
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'clang-format-docker/**'
       - '.github/workflows/clang-format-image.yml'
@@ -60,48 +62,48 @@ jobs:
           tags: ${{ env.REGISTRY}}/jidicula/${{ env.IMAGE_NAME}}:${{ env.MAJOR_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  # get-src:
-  #   name: clang-format ${{ matrix.version }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       version: [ "6.0.1", "5.0.2", "4.0.1"]
-  #   steps:
-  #     - run: |
-  #         VERSION="${{ matrix.version }}"
-  #         MAJOR_VERSION="${VERSION%%.*}"
-  #         echo "MAJOR_VERSION=$MAJOR_VERSION" >> "$GITHUB_ENV"
-  #     - uses: actions/checkout@v2
-  #     - name: Clone llvm-project ${{ matrix.version }}
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: 'llvm/llvm-project'
-  #         ref: 'llvmorg-${{ matrix.version }}'
-  #         path: llvm-project
-  #     - name: Build clang-format
-  #       run: |
-  #         cd llvm-project
-  #         mkdir build && cd build
-  #         cmake -DLLVM_ENABLE_PROJECTS=clang -G "Unix Makefiles" ../llvm
-  #         make clang-format
-  #         mv bin ../..
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v1.12.0
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Extract metadata (tags, labels) for Docker
-  #       id: meta
-  #       uses: docker/metadata-action@v3.6.2
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-  #     - name: Build and push Docker image
-  #       uses: docker/build-push-action@v2.7.0
-  #       with:
-  #         context: .
-  #         file: "clang-format-docker/Dockerfile"
-  #         push: true
-  #         tags: ${{ env.REGISTRY}}/jidicula/${{ env.IMAGE_NAME}}:${{ env.MAJOR_VERSION }}
-  #         labels: ${{ steps.meta.outputs.labels }}
+  get-src:
+    name: clang-format ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "6.0.1", "5.0.2", "4.0.1"]
+    steps:
+      - run: |
+          VERSION="${{ matrix.version }}"
+          MAJOR_VERSION="${VERSION%%.*}"
+          echo "MAJOR_VERSION=$MAJOR_VERSION" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v2
+      - name: Clone llvm-project ${{ matrix.version }}
+        uses: actions/checkout@v2
+        with:
+          repository: 'llvm/llvm-project'
+          ref: 'llvmorg-${{ matrix.version }}'
+          path: llvm-project
+      - name: Build clang-format
+        run: |
+          cd llvm-project
+          mkdir build && cd build
+          cmake -DLLVM_ENABLE_PROJECTS=clang -G "Unix Makefiles" ../llvm
+          make clang-format
+          mv bin ../..
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          file: "clang-format-docker/Dockerfile"
+          push: true
+          tags: ${{ env.REGISTRY}}/jidicula/${{ env.IMAGE_NAME}}:${{ env.MAJOR_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -1,0 +1,107 @@
+name: docker-clang-format
+
+on:
+  push:
+    paths:
+      - 'clang-format-docker/**'
+      - '.github/workflows/clang-format-image.yml'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: clang-format
+
+jobs:
+  get-binary:
+    name: clang-format ${{ matrix.version-pair.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version-pair:
+          - {version: "13.0.0", ubuntu: "20.04"}
+          - {version: "12.0.1", ubuntu: "16.04"}
+          - {version: "11.1.0", ubuntu: "20.10"}
+          - {version: "10.0.1", ubuntu: "16.04"}
+          - {version: "9.0.1", ubuntu: "16.04"}
+          - {version: "8.0.1", ubuntu: "14.04"}
+          - {version: "7.1.0", ubuntu: "14.04"}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get llvm-project binary tar.xz
+        run: |
+          VERSION="${{ matrix.version-pair.version }}"
+          MAJOR_VERSION="${VERSION%%.*}"
+          echo "MAJOR_VERSION=$MAJOR_VERSION" >> "$GITHUB_ENV"
+          TARBALL="clang+llvm-${{ matrix.version-pair.version }}-x86_64-linux-gnu-ubuntu-${{ matrix.version-pair.ubuntu }}.tar.xz"
+          wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.version-pair.version }}/$TARBALL"
+          tar -xf "$TARBALL" && ls
+          mv clang*/bin .
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          file: "clang-format-docker/Dockerfile"
+          push: true
+          tags: ${{ env.REGISTRY}}/jidicula/${{ env.IMAGE_NAME}}:${{ env.MAJOR_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # get-src:
+  #   name: clang-format ${{ matrix.version }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       version: [ "6.0.1", "5.0.2", "4.0.1"]
+  #   steps:
+  #     - run: |
+  #         VERSION="${{ matrix.version }}"
+  #         MAJOR_VERSION="${VERSION%%.*}"
+  #         echo "MAJOR_VERSION=$MAJOR_VERSION" >> "$GITHUB_ENV"
+  #     - uses: actions/checkout@v2
+  #     - name: Clone llvm-project ${{ matrix.version }}
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: 'llvm/llvm-project'
+  #         ref: 'llvmorg-${{ matrix.version }}'
+  #         path: llvm-project
+  #     - name: Build clang-format
+  #       run: |
+  #         cd llvm-project
+  #         mkdir build && cd build
+  #         cmake -DLLVM_ENABLE_PROJECTS=clang -G "Unix Makefiles" ../llvm
+  #         make clang-format
+  #         mv bin ../..
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v1.12.0
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Extract metadata (tags, labels) for Docker
+  #       id: meta
+  #       uses: docker/metadata-action@v3.6.2
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+  #     - name: Build and push Docker image
+  #       uses: docker/build-push-action@v2.7.0
+  #       with:
+  #         context: .
+  #         file: "clang-format-docker/Dockerfile"
+  #         push: true
+  #         tags: ${{ env.REGISTRY}}/jidicula/${{ env.IMAGE_NAME}}:${{ env.MAJOR_VERSION }}
+  #         labels: ${{ steps.meta.outputs.labels }}

--- a/clang-format-docker/Dockerfile
+++ b/clang-format-docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY bin/clang-format .


### PR DESCRIPTION
This fetches `clang-format` binaries in LLVM versions with associated
GitHub releases. For older versions, `clang-format` is built from
source where possible to use the Makefile target for `clang-format`.

Note that this pulls down the latest patch version for this Action's
supported major versions and tags the image with the major version
only.

Part of a refactor of this action to a composite action.