### PR TITLE
fix(clang-format-docker): Use bullseye-slim

### DIFF
--- a/clang-format-docker/Dockerfile
+++ b/clang-format-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM debian:bullseye-slim
 COPY bin/clang-format /clang-format
 
 ENTRYPOINT ["/clang-format", "-n", "--Werror", "--style=file"]


### PR DESCRIPTION
Might be relying on some linked libs to work.