### PR TITLE
fix(clang-format-docker): Include binary directory in Docker image

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -40,8 +40,8 @@ jobs:
           echo "MAJOR_VERSION=$MAJOR_VERSION" >> "$GITHUB_ENV"
           TARBALL="clang+llvm-${{ matrix.version-pair.version }}-x86_64-linux-gnu-ubuntu-${{ matrix.version-pair.ubuntu }}.tar.xz"
           wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.version-pair.version }}/$TARBALL"
-          tar -xf "$TARBALL" && ls
-          mv clang*/bin .
+          tar -xf "$TARBALL" && rm *tar.xz
+          mv clang* clang
       - name: Log in to the Container registry
         uses: docker/login-action@v1.12.0
         with:
@@ -84,10 +84,11 @@ jobs:
       - name: Build clang-format
         run: |
           cd llvm-project
-          mkdir build && cd build
+          mkdir clang && cd clang
           cmake -DLLVM_ENABLE_PROJECTS=clang -G "Unix Makefiles" ../llvm
           make clang-format
-          mv bin ../..
+          cd ..
+          mv clang ..
       - name: Log in to the Container registry
         uses: docker/login-action@v1.12.0
         with:

--- a/clang-format-docker/Dockerfile
+++ b/clang-format-docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM debian:bullseye-slim
-COPY bin/clang-format /clang-format
+COPY clang .
 
-ENTRYPOINT ["/clang-format"]
+ENTRYPOINT ["/clang/bin/clang-format"]


### PR DESCRIPTION
`clang-format` is not a statically linked binary, so we need to copy
in all the shared libs and other binaries so it can work properly.