### PR TITLE
Quote arguments to check.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/check.sh  ${{ inputs.clang-format-version }} ${{ inputs.check-path }} ${{ inputs.fallback-style }} ${{ inputs.exclude-regex }}
+    - run: >
+        "${{ github.action_path }}/check.sh" "${{ inputs.clang-format-version }}" "${{ inputs.check-path }}" "${{ inputs.fallback-style }}" "${{ inputs.exclude-regex }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: >
+    - run: |
         "${{ github.action_path }}/check.sh" "${{ inputs.clang-format-version }}" "${{ inputs.check-path }}" "${{ inputs.fallback-style }}" "${{ inputs.exclude-regex }}"
       shell: bash


### PR DESCRIPTION
Arguments would get expanded before being passed to bash, which would cause the following configuration to fail:

```yaml
clang-format-version: 12
check-path: '.'
exclude-regex: '(foo|bar)'
```

because `check.sh` would get run as:

```bash
check.sh 12 . LLVM (foo|bar)
```

And since '(' and '|' are special characters for bash, the action will immediately fail because of a syntax error.

Instead, it should get ran as:

```bash
check.sh "12" "." "LLVM" "(foo|bar)"
```

This should also ensure that `check-path` works with paths containing spaces.