### PR TITLE
feat(ubuntu): Retire impish images

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -28,11 +28,11 @@ jobs:
       matrix:
         version-pair:
           - {version: "14", ubuntu: "jammy"}
-          - {version: "13", ubuntu: "impish"}
-          - {version: "12", ubuntu: "impish"}
-          - {version: "11", ubuntu: "impish"}
+          - {version: "13", ubuntu: "jammy"}
+          - {version: "12", ubuntu: "jammy"}
+          - {version: "11", ubuntu: "jammy"}
           - {version: "10", ubuntu: "focal"}
-          - {version: "9", ubuntu: "impish"}
+          - {version: "9", ubuntu: "focal"}
           - {version: "8", ubuntu: "focal"}
           - {version: "7", ubuntu: "focal"}
           - {version: "6.0", ubuntu: "focal"}


### PR DESCRIPTION
Ubuntu Impish seems to be unsupported now and its Release files seem
to have been removed from the Ubuntu repositories.

> #6 1.390 E: The repository 'http://security.ubuntu.com/ubuntu impish-security Release' does not have a Release file.

See failures in https://github.com/jidicula/clang-format-action/runs/7485540299?check_suite_focus=true