### PR TITLE
ci(runner): Run tests on specific Ubuntu versions

### DIFF
--- a/.github/workflows/test-ubuntu-18.04.yml
+++ b/.github/workflows/test-ubuntu-18.04.yml
@@ -1,0 +1,20 @@
+name: ubuntu-18.04
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: ubuntu-18.04
+    uses: ./.github/workflows/tests.yml
+    with:
+      runner-os: "ubuntu-18.04"

--- a/.github/workflows/test-ubuntu-18.04.yml
+++ b/.github/workflows/test-ubuntu-18.04.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   tests:
-    name: ubuntu-18.04
+    name: Tests
     uses: ./.github/workflows/tests.yml
     with:
       runner-os: "ubuntu-18.04"

--- a/.github/workflows/test-ubuntu-20.04.yml
+++ b/.github/workflows/test-ubuntu-20.04.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   tests:
-    name: ubuntu-20.04
+    name: Tests
     uses: ./.github/workflows/tests.yml
     with:
       runner-os: "ubuntu-20.04"

--- a/.github/workflows/test-ubuntu-20.04.yml
+++ b/.github/workflows/test-ubuntu-20.04.yml
@@ -1,0 +1,20 @@
+name: ubuntu-20.04
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: ubuntu-20.04
+    uses: ./.github/workflows/tests.yml
+    with:
+      runner-os: "ubuntu-20.04"

--- a/.github/workflows/test-ubuntu-22.04.yml
+++ b/.github/workflows/test-ubuntu-22.04.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   tests:
-    name: ubuntu-22.04
+    name: Tests
     uses: ./.github/workflows/tests.yml
     with:
       runner-os: "ubuntu-22.04"

--- a/.github/workflows/test-ubuntu-22.04.yml
+++ b/.github/workflows/test-ubuntu-22.04.yml
@@ -1,0 +1,20 @@
+name: ubuntu-22.04
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: ubuntu-22.04
+    uses: ./.github/workflows/tests.yml
+    with:
+      runner-os: "ubuntu-22.04"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,11 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      runner-os:
+        required: true
+        type: string
 
 defaults:
   run:
@@ -14,12 +13,12 @@ defaults:
 
 jobs:
   test:
-    name: clang-format-${{ matrix.version }}
-    runs-on: ubuntu-latest
+    name: clang-format-${{ matrix.clang-format-version }}
+    runs-on: ${{ inputs.runner-os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
+        clang-format-version:
           - 3
           - 4
           - 5
@@ -35,4 +34,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build and test the Docker image
-      run: test/test.sh ${{ matrix.version }}
+      run: test/test.sh ${{ matrix.clang-format-version }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Tests](https://github.com/jidicula/clang-format-action/actions/workflows/tests.yml/badge.svg)](https://github.com/jidicula/clang-format-action/actions/workflows/tests.yml) [![shell-lint](https://github.com/jidicula/clang-format-action/workflows/shell-lint/badge.svg?branch=main)](https://github.com/jidicula/clang-format-action/actions?query=workflow%3Ashell-lint+branch%3Amain)
+[![ubuntu-18.04](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-18.04.yml/badge.svg)](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-18.04.yml) [![ubuntu-20.04](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-20.04.yml/badge.svg)](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-20.04.yml) [![ubuntu-22.04](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-22.04.yml/badge.svg)](https://github.com/jidicula/clang-format-action/actions/workflows/test-ubuntu-22.04.yml)
+
+[![shell-lint](https://github.com/jidicula/clang-format-action/workflows/shell-lint/badge.svg?branch=main)](https://github.com/jidicula/clang-format-action/actions?query=workflow%3Ashell-lint+branch%3Amain)
+
 
 # clang-format-action
 GitHub Action for `clang-format` checks. Note that this Action does **NOT** format your code for you - it only verifies that your repository's code follows your project's formatting conventions.


### PR DESCRIPTION
Factors out runner OS into separate workflows that each call a shared
test matrix workflow. This allows CI status badges for each runner OS,
rather than a single status badge for all OSes.

Having a CI status badge for each supported runner OS allows
at-a-glance judgement of this Action's maintenance status.

Resolves: #106