### PR TITLE
feat(version): Add clang-format-15

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         version-pair:
+          - {version: "15", ubuntu: "kinetic"}
           - {version: "14", ubuntu: "jammy"}
           - {version: "13", ubuntu: "jammy"}
           - {version: "12", ubuntu: "jammy"}


### PR DESCRIPTION
Note that clang-format-15 is only available in Ubuntu 22.10, Kinetic Kudu, which is still in beta at the time of this commit.

Related to: #112