### PR TITLE
feat(version): Add clang-format-15 to Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           - 12
           - 13
           - 14
+          - 15
     steps:
     - uses: actions/checkout@v3
     - name: Build and test the Docker image

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can define your own formatting rules in a `.clang-format` file at your repos
 * `clang-format-12`
 * `clang-format-13`
 * `clang-format-14`
+* `clang-format-15`
 
 ## Do you find this useful?
 


### PR DESCRIPTION
Note that clang-format-15 is only available in Ubuntu 22.10, Kinetic Kudu, which is still in beta at the time of this commit.

Resolves: #112