### PR TITLE
Use `github.server_url` property

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,6 @@ runs:
     - name: Report failure in job summary
       if: failure()
       run: |
-        DEEPLINK="https://github.com/${{ github.repository }}/commit/${{ env.SHA }}"
+        DEEPLINK="${{ github.server_url }}/${{ github.repository }}/commit/${{ env.SHA }}"
         echo -e "Format check failed on commit [${GITHUB_SHA:0:8}]($DEEPLINK) with files:\n$(<$GITHUB_WORKSPACE/failing-files.txt)" >> $GITHUB_STEP_SUMMARY
       shell: bash


### PR DESCRIPTION
Instead of hardcoding the GitHub URL, instead pull in the server URL from the `github` object.