### PR TITLE
Add support for clang-format-17

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         version-pair:
+          - {version: "17", ubuntu: "mantic"}
           - {version: "16", ubuntu: "lunar"}
           - {version: "15", ubuntu: "lunar"}
           - {version: "14", ubuntu: "jammy"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           - 14
           - 15
           - 16
+          - 17
     steps:
     - uses: actions/checkout@v4
     - name: Build and test the Docker image
@@ -61,6 +62,7 @@ jobs:
           - 14
           - 15
           - 16
+          - 17
         path:
           - check: 'test/known_fail'
             exclude: 'capi'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can define your own formatting rules in a `.clang-format` file at your repos
 * 14: `clang-format-14`
 * 15: `clang-format-15`
 * 16: `clang-format-16`
+* 17: `clang-format-17`
 
 ## Do you find this useful?
 


### PR DESCRIPTION
Hi @jidicula,

I am creating this Pull Request in relation with the issue #162 :slightly_smiling_face:  (and in the context of Hacktoberfest 2023). 
I've inspired myself a lot from the Pull Requests you have linked in the issue description.

Currently, I am trying to run the script `test/test.sh` like you mentioned in the [CONTRIBUTING](https://github.com/jidicula/clang-format-action/blob/main/CONTRIBUTING.md), but I am currently having the following error:

```
Unable to find image 'ghcr.io/jidicula/clang-format:17' locally
``` 

and,

```shell
$ docker pull ghcr.io/jidicula/clang-format:17
Error response from daemon: manifest unknown
```

Maybe GitHub Actions will have the right setup, and not have this issue.
Until GitHub Actions gives me some results, I'll continue seeing if I can solve this issue on my end :wink: 