### PR TITLE
refactor: Switch Ubuntu version to mantic

### DIFF
--- a/.github/workflows/clang-format-image.yml
+++ b/.github/workflows/clang-format-image.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         version-pair:
           - {version: "17", ubuntu: "mantic"}
-          - {version: "16", ubuntu: "lunar"}
-          - {version: "15", ubuntu: "lunar"}
-          - {version: "14", ubuntu: "jammy"}
-          - {version: "13", ubuntu: "jammy"}
+          - {version: "16", ubuntu: "mantic"}
+          - {version: "15", ubuntu: "mantic"}
+          - {version: "14", ubuntu: "mantic"}
+          - {version: "13", ubuntu: "mantic"}
           - {version: "12", ubuntu: "jammy"}
           - {version: "11", ubuntu: "jammy"}
           - {version: "10", ubuntu: "focal"}


### PR DESCRIPTION
issue: #165
### Refactoring
For ubuntu versions 13-16 switched the version to mantic in the .github\workflows\clang-format-image.yml

#### What it does?
closes #165 