### PR TITLE
Adds `format-filepath` to customize the filepath of `.clang-format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
 * `include-regex` [optional]: A regex to include files or directories that should be checked.
   * Default: see [`INCLUDE_REGEX`](./check.sh#77)
   * Pattern matching is done with a POSIX `grep -E` extended regex, **not** a glob expression. You can exclude multiple patterns like this: `(hello|world)`. Build and verify your regex at [regex101.com](https://regex101.com) ([example](https://regex101.com/r/llFcLy/7)).
-* `format-filepath` [optional]: A filepath to the clang_format file to override the default, which is `.clang_format` in the directory closest to the parent.'
+* `format-filepath` [optional]: A filepath to the clang_format file to override the default, which is `.clang_format` file located in the closest parent directory of the input file.'
     default: ''
 
 This action checks all C/C++/Protobuf (including Arduino `.ino` and `.pde`) files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++/Protobuf files are checked.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
 * `include-regex` [optional]: A regex to include files or directories that should be checked.
   * Default: see [`INCLUDE_REGEX`](./check.sh#77)
   * Pattern matching is done with a POSIX `grep -E` extended regex, **not** a glob expression. You can exclude multiple patterns like this: `(hello|world)`. Build and verify your regex at [regex101.com](https://regex101.com) ([example](https://regex101.com/r/llFcLy/7)).
+* `format-filepath` [optional]: A filepath to the clang_format file to override the default, which is `.clang_format` in the directory closest to the parent.'
+    default: ''
 
 This action checks all C/C++/Protobuf (including Arduino `.ino` and `.pde`) files in the provided directory in the GitHub workspace are formatted correctly using `clang-format`. If no directory is provided or the provided path is not a directory in the GitHub workspace, all C/C++/Protobuf files are checked.
 

--- a/action.yml
+++ b/action.yml
@@ -26,12 +26,16 @@ inputs:
     description: 'A regex to override the C/C++/Protobuf/CUDA filetype regex. that should be checked. Default results in the regex defined in `check.sh`.'
     required: false
     default: ''
+  format-filepath:
+    description: 'A filepath to the clang_format file to override the default, which is `.clang_format` in the directory closest to the parent.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
     - run: |
-        "${{ github.action_path }}/check.sh" "${{ inputs.clang-format-version }}" "${{ inputs.check-path }}" "${{ inputs.fallback-style }}" "${{ inputs.exclude-regex }}" "${{ inputs.include-regex }}"
+        "${{ github.action_path }}/check.sh" "${{ inputs.clang-format-version }}" "${{ inputs.check-path }}" "${{ inputs.fallback-style }}" "${{ inputs.exclude-regex }}" "${{ inputs.include-regex }}" "${{ inputs.format-filepath }}"
       shell: bash
     - name: Save PR head commit SHA
       if: failure() && github.event_name == 'pull_request'

--- a/check.sh
+++ b/check.sh
@@ -86,9 +86,10 @@ if [[ ! -d $CHECK_PATH ]]; then
 fi
 
 if [[ ! -f $FORMAT_FILEPATH ]]; then
-	echo "Not a file in the workspace, fallback to .clang_format." >&2
+	echo "Not a file in the workspace, fallback to search for .clang_format." >&2
 	FORMAT_FILEPATH=""
 else
+	# if being used, add the colon for seperating the syntax file:<file_name>
 	FORMAT_FILEPATH=":$FORMAT_FILEPATH"
 fi
 

--- a/check.sh
+++ b/check.sh
@@ -27,7 +27,7 @@ format_diff() {
 			ghcr.io/jidicula/clang-format:"$CLANG_FORMAT_MAJOR_VERSION" \
 			--dry-run \
 			--Werror \
-			--style=file \
+			--style=file"$FORMAT_FILEPATH" \
 			--fallback-style="$FALLBACK_STYLE" \
 			"${filepath}")"
 	else # Versions below 9 don't have dry run
@@ -35,7 +35,7 @@ format_diff() {
 			--volume "$(pwd)":"$(pwd)" \
 			--workdir "$(pwd)" \
 			ghcr.io/jidicula/clang-format:"$CLANG_FORMAT_MAJOR_VERSION" \
-			--style=file \
+			--style=file"$FORMAT_FILEPATH" \
 			--fallback-style="$FALLBACK_STYLE" \
 			"${filepath}")"
 		local_format="$(diff -q <(cat "${filepath}") <(echo "${formatted}"))"
@@ -60,6 +60,7 @@ CHECK_PATH="$2"
 FALLBACK_STYLE="$3"
 EXCLUDE_REGEX="$4"
 INCLUDE_REGEX="$5"
+FORMAT_FILEPATH="$6"
 
 # Set the regex to an empty string regex if nothing was provided
 if [[ -z $EXCLUDE_REGEX ]]; then
@@ -82,6 +83,13 @@ cd "$GITHUB_WORKSPACE" || exit 2
 if [[ ! -d $CHECK_PATH ]]; then
 	echo "Not a directory in the workspace, fallback to all files." >&2
 	CHECK_PATH="."
+fi
+
+if [[ ! -f $FORMAT_FILEPATH ]]; then
+	echo "Not a file in the workspace, fallback to .clang_format." >&2
+	FORMAT_FILEPATH=""
+else
+	FORMAT_FILEPATH=":$FORMAT_FILEPATH"
 fi
 
 # initialize exit code


### PR DESCRIPTION
See title.  

This allows any file with valid clang format contents to be specified as the filepath.  

In my organization this allows a submodule common across multiple C repositories to contain the `clang-format`, so an update of the submodule updates the styling across the org.

